### PR TITLE
Add support for accessing nested properties through column type contents.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,5 +3,4 @@ VITE_CONTENTSTACK_ENVIRONMENT=development
 VITE_CONTENTSTACK_DELIVERY_TOKEN=cs4ba8ed9266b09c63d237a48e
 VITE_CONTENTSTACK_BRANCH=main
 VITE_CONTENT_TYPE=Blog_Article
-VITE_CONTENT_TYPE_COLUMNS=[{"id": "title", "name": "Title"}, {"id": "sort_date", "name": "Date"}]
-
+VITE_CONTENT_TYPE_COLUMNS=[{"id":"title","name":"Title"},{"id":"url","name":"Link"},{"id":"metadata.opengraph_image.url","name":"Image"},{"id":"metadata.thumbnail_image.url","name":"Thumnbail"}]

--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ Override default environment variables in [.env.development](.env.development) b
 # Build
 
 Entire codebase is compiled into a single html file (`dist/index.html`) via `yarn build` command. The code in the file should be copied/pasted into "Hosting method => Hosted by Contenstack => Extension source code" field. when adding the extension in Contentstack.
-
-test

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Override default environment variables in [.env.development](.env.development) b
 
 Entire codebase is compiled into a single html file (`dist/index.html`) via `yarn build` command. The code in the file should be copied/pasted into "Hosting method => Hosted by Contenstack => Extension source code" field. when adding the extension in Contentstack.
 
+test

--- a/src/components/ContentstackReferenceField.tsx
+++ b/src/components/ContentstackReferenceField.tsx
@@ -37,7 +37,25 @@ export const ContentstackReferenceField: React.FC<Props> = ({query, queryColumns
           <ContentstackReferenceFieldSelector query={query} queryColumns={queryColumns} onReferenceSelected={(reference) => {
             onChange({
               uid: reference.uid,
-              fields: Object.fromEntries(queryColumns.map(({id}) => ([id, reference[id]]))) 
+              fields: Object.fromEntries(queryColumns.map(({id}) => {
+                
+                // support targeting nested fields with dot notation
+                // e.g. 'field.nestedField'
+                const keys:string[] = id.split('.');
+                const value = keys.reduce((acc: unknown, key: string) => {
+                  if (acc === null || acc === undefined) {
+                    return;
+                  }
+                  if (typeof acc !== 'object') {
+                    return acc
+                  }                  
+                  return (acc as {[key: string]: unknown})[key];
+                }, {...reference})
+                
+                // Contentstack doesn't allow '.' in the field name, so we replace with '-'
+                const key = id.replace(/\./g, '-');
+                return [key, value]
+              }),) 
             })
             setOpen(false)
           }} />


### PR DESCRIPTION
The extension currently works really well for accessing top level properties on the contentstack entry. We have another use case where we'd like to add support for targeting deeply nested fields within the contentstack entry. For example, in the following object, we might want to pluck out the url for the image. 
```
{
   title: "some title",
   metadata: {
       image: {
           url: "some path to an image"
       }
   }
}
```
This PR allows you to add a full path to the field you want. For example, to target the image url above you would use "metadata.image.url" as the id for the column when configuring the extension. 

One downside is that contentstack doesn't allow dots when saving the field back. So the dots need to be replaced.  When the field is saved, it becomes "metadata-image-url".

Apologies for the typescript casting on line 52 below in the reduce function. If you have a better way of doing that, i'm open to suggestions. 

Cheers, 
Joe
